### PR TITLE
fix: added support for China Partition

### DIFF
--- a/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
+++ b/src/lambda_codebase/initial_commit/bootstrap_repository/adf-build/shared/python/partition.py
@@ -10,7 +10,7 @@ https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genre
 
 from boto3.session import Session
 
-COMPATIBLE_PARTITIONS = ['aws-us-gov', 'aws']
+COMPATIBLE_PARTITIONS = ['aws-us-gov', 'aws', 'aws-cn']
 
 
 class IncompatiblePartitionError(Exception):
@@ -35,13 +35,14 @@ def get_partition(region_name: str) -> str:
 
 def get_organization_api_region(region_name: str) -> str:
     """
-    Given the current region, it will determine the partition and use
-    that to return the Organizations API region (us-east-1 or us-gov-west-1)
+    Given the current region, it will determine it's partition and use
+    that to determine the Organizations API region (us-east-1, us-gov-west-1 or cn-northwest-1)
 
-    :param region_name: The name of the region (eu-west-1, us-gov-east-1)
+    :param region_name: The name of the AWS region (eg. us-east-2)
     :return: Returns the AWS Organizations API region to use as a string.
     """
     if get_partition(region_name) == 'aws-us-gov':
         return 'us-gov-west-1'
-
+    if get_partition(region_name) == 'aws-cn':
+        return 'cn-northwest-1'
     return 'us-east-1'


### PR DESCRIPTION
# Why?

Required for OU Path based deployments in ADF when using China Regions.

